### PR TITLE
feat: add support for dynamic rate limit configurations with hot reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "indoc",
  "insta",
  "lambda_http",
+ "notify",
  "parser-sdl",
  "regex",
  "reqwest",

--- a/cli/crates/federated-dev/src/dev/gateway_nanny.rs
+++ b/cli/crates/federated-dev/src/dev/gateway_nanny.rs
@@ -9,6 +9,7 @@ use futures_concurrency::stream::Merge;
 use futures_util::{future::BoxFuture, stream::BoxStream, FutureExt as _, StreamExt};
 use runtime::rate_limiting::KeyedRateLimitConfig;
 use runtime_local::rate_limiting::in_memory::key_based::InMemoryRateLimiter;
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::WatchStream;
 
 /// The GatewayNanny looks after the `Gateway` - on updates to the graph or config it'll
@@ -56,7 +57,7 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
         .into_iter()
         .map(|(k, v)| {
             (
-                k,
+                k.to_string(),
                 runtime::rate_limiting::GraphRateLimit {
                     limit: v.limit,
                     duration: v.duration,
@@ -65,6 +66,8 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
         })
         .collect::<HashMap<_, _>>();
 
+    let (_, rx) = mpsc::channel(100);
+
     let runtime = CliRuntime {
         fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
         trusted_documents: runtime::trusted_documents_client::Client::new(
@@ -72,7 +75,7 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
         ),
         kv: runtime_local::InMemoryKvStore::runtime(),
         meter: grafbase_telemetry::metrics::meter_from_global_provider(),
-        rate_limiter: InMemoryRateLimiter::runtime(KeyedRateLimitConfig { rate_limiting_configs }),
+        rate_limiter: InMemoryRateLimiter::runtime(KeyedRateLimitConfig { rate_limiting_configs }, rx),
     };
 
     let schema = config.try_into().ok()?;

--- a/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
+++ b/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
@@ -4,6 +4,7 @@ use runtime_local::{
     rate_limiting::in_memory::key_based::InMemoryRateLimiter, InMemoryHotCacheFactory, InMemoryKvStore, NativeFetcher,
 };
 use runtime_noop::trusted_documents::NoopTrustedDocuments;
+use tokio::sync::mpsc;
 
 pub struct TestRuntime {
     pub fetcher: runtime::fetch::Fetcher,
@@ -16,13 +17,14 @@ pub struct TestRuntime {
 
 impl Default for TestRuntime {
     fn default() -> Self {
+        let (_, rx) = mpsc::channel(100);
         Self {
             fetcher: NativeFetcher::runtime_fetcher(),
             trusted_documents: trusted_documents_client::Client::new(NoopTrustedDocuments),
             kv: InMemoryKvStore::runtime(),
             meter: metrics::meter_from_global_provider(),
             hooks: Default::default(),
-            rate_limiter: InMemoryRateLimiter::runtime(Default::default()),
+            rate_limiter: InMemoryRateLimiter::runtime(Default::default(), rx),
         }
     }
 }

--- a/engine/crates/runtime/src/rate_limiting.rs
+++ b/engine/crates/runtime/src/rate_limiting.rs
@@ -59,6 +59,6 @@ pub struct GraphRateLimit {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct KeyedRateLimitConfig<'a> {
-    pub rate_limiting_configs: HashMap<&'a str, GraphRateLimit>,
+pub struct KeyedRateLimitConfig {
+    pub rate_limiting_configs: HashMap<String, GraphRateLimit>,
 }

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -54,6 +54,8 @@ axum-aws-lambda = { version = "0.7.0", optional = true }
 tower = { workspace = true, optional = true }
 lambda_http = { version = "0.11.1", optional = true }
 serde_regex = "1.1.0"
+notify = "6.1.1"
+toml = "0.8.12"
 
 [dev-dependencies]
 indoc = "2.0.5"

--- a/gateway/crates/federated-server/src/config/hot_reload.rs
+++ b/gateway/crates/federated-server/src/config/hot_reload.rs
@@ -1,0 +1,124 @@
+use std::{collections::HashMap, fs, path::PathBuf, sync::OnceLock, time::Duration};
+
+use grafbase_telemetry::span::GRAFBASE_TARGET;
+use notify::{EventHandler, EventKind, PollWatcher, Watcher};
+use runtime::rate_limiting::GraphRateLimit;
+use tokio::sync::{mpsc, watch};
+
+use crate::Config;
+
+type RateLimitData = HashMap<String, GraphRateLimit>;
+
+pub(crate) enum RateLimitSender {
+    Watch(watch::Sender<RateLimitData>),
+    Mpsc(mpsc::Sender<RateLimitData>),
+}
+
+impl RateLimitSender {
+    fn send(&self, data: RateLimitData) -> crate::Result<()> {
+        match self {
+            RateLimitSender::Watch(channel) => Ok(channel.send(data)?),
+            RateLimitSender::Mpsc(channel) => Ok(channel.blocking_send(data)?),
+        }
+    }
+}
+
+impl From<watch::Sender<RateLimitData>> for RateLimitSender {
+    fn from(value: watch::Sender<RateLimitData>) -> Self {
+        Self::Watch(value)
+    }
+}
+
+impl From<mpsc::Sender<RateLimitData>> for RateLimitSender {
+    fn from(value: mpsc::Sender<RateLimitData>) -> Self {
+        Self::Mpsc(value)
+    }
+}
+
+pub(crate) struct ConfigWatcher {
+    config_path: PathBuf,
+    rate_limit_sender: RateLimitSender,
+}
+
+impl ConfigWatcher {
+    pub fn new(config_path: PathBuf, rate_limit_sender: impl Into<RateLimitSender>) -> Self {
+        Self {
+            config_path,
+            rate_limit_sender: rate_limit_sender.into(),
+        }
+    }
+
+    pub fn watch(self) -> crate::Result<()> {
+        static WATCHER: OnceLock<PollWatcher> = OnceLock::new();
+
+        WATCHER.get_or_init(|| {
+            let config = notify::Config::default().with_poll_interval(Duration::from_secs(1));
+            let path = self.config_path.clone();
+            let mut watcher = PollWatcher::new(self, config).expect("config watch init failed");
+
+            watcher
+                .watch(&path, notify::RecursiveMode::NonRecursive)
+                .expect("config watch failed");
+
+            watcher
+        });
+
+        Ok(())
+    }
+
+    fn reload_config(&self) -> crate::Result<()> {
+        let config = match fs::read_to_string(&self.config_path) {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::error!(target: GRAFBASE_TARGET, "error reading gateway config: {e}");
+
+                return Ok(());
+            }
+        };
+
+        let config: Config = match toml::from_str(&config) {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::error!(target: GRAFBASE_TARGET, "error parsing gateway config: {e}");
+
+                return Ok(());
+            }
+        };
+
+        let rate_limiting_configs = config
+            .as_keyed_rate_limit_config()
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    runtime::rate_limiting::GraphRateLimit {
+                        limit: v.limit,
+                        duration: v.duration,
+                    },
+                )
+            })
+            .collect();
+
+        self.rate_limit_sender.send(rate_limiting_configs)?;
+
+        Ok(())
+    }
+}
+
+impl EventHandler for ConfigWatcher {
+    fn handle_event(&mut self, event: notify::Result<notify::Event>) {
+        match event.map(|e| e.kind) {
+            Ok(EventKind::Any | EventKind::Create(_) | EventKind::Modify(_) | EventKind::Other) => {
+                tracing::debug!(target: GRAFBASE_TARGET, "reloading configuration file");
+
+                if let Err(e) = self.reload_config() {
+                    tracing::error!(target: GRAFBASE_TARGET, "error reloading gateway config: {e}");
+                };
+            }
+            Ok(_) => (),
+            Err(e) => {
+                tracing::error!(target: GRAFBASE_TARGET, "error reading gateway config: {e}");
+            }
+        }
+    }
+}

--- a/gateway/crates/federated-server/src/config/rate_limit.rs
+++ b/gateway/crates/federated-server/src/config/rate_limit.rs
@@ -4,7 +4,7 @@ use serde::Deserializer;
 use std::path::PathBuf;
 use std::time::Duration;
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GraphRateLimit {
     pub limit: usize,

--- a/gateway/crates/federated-server/src/error.rs
+++ b/gateway/crates/federated-server/src/error.rs
@@ -1,4 +1,4 @@
-use tokio::sync::watch::error::SendError;
+use tokio::sync::{mpsc, watch};
 
 /// The Grafbase gateway error type
 #[derive(Debug, thiserror::Error)]
@@ -17,8 +17,14 @@ pub enum Error {
     Server(#[source] std::io::Error),
 }
 
-impl<T> From<SendError<T>> for Error {
-    fn from(value: SendError<T>) -> Self {
+impl<T> From<watch::error::SendError<T>> for Error {
+    fn from(value: watch::error::SendError<T>) -> Self {
+        Self::InternalError(value.to_string())
+    }
+}
+
+impl<T> From<mpsc::error::SendError<T>> for Error {
+    fn from(value: mpsc::error::SendError<T>) -> Self {
         Self::InternalError(value.to_string())
     }
 }

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -16,4 +16,4 @@ mod server;
 /// The crate result type.
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub use server::serve;
+pub use server::{serve, ServerConfig};

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -2,7 +2,7 @@ mod lambda;
 mod log;
 mod std;
 
-use ::std::net::SocketAddr;
+use ::std::{net::SocketAddr, path::Path};
 
 use clap::Parser;
 use federated_server::{Config, GraphFetchMethod};
@@ -19,6 +19,10 @@ pub(crate) trait Args {
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod>;
 
     fn config(&self) -> anyhow::Result<Config>;
+
+    fn config_path(&self) -> Option<&Path>;
+
+    fn hot_reload(&self) -> bool;
 
     fn log_format<S>(&self) -> BoxedLayer<S>
     where

--- a/gateway/crates/gateway-binary/src/args/lambda.rs
+++ b/gateway/crates/gateway-binary/src/args/lambda.rs
@@ -1,4 +1,8 @@
-use std::{fs, io::ErrorKind, path::PathBuf};
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use clap::Parser;
@@ -49,6 +53,10 @@ impl super::Args for Args {
         }
     }
 
+    fn config_path(&self) -> Option<&Path> {
+        Some(&self.config)
+    }
+
     fn log_format<S>(&self) -> BoxedLayer<S>
     where
         S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
@@ -62,6 +70,10 @@ impl super::Args for Args {
             LogStyle::Text => layer.with_ansi(false).with_target(false).boxed(),
             LogStyle::Json => layer.json().boxed(),
         }
+    }
+
+    fn hot_reload(&self) -> bool {
+        false
     }
 
     fn listen_address(&self) -> Option<std::net::SocketAddr> {

--- a/gateway/crates/gateway-binary/src/args/std.rs
+++ b/gateway/crates/gateway-binary/src/args/std.rs
@@ -1,4 +1,8 @@
-use std::{fs, net::SocketAddr, path::PathBuf};
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use ascii::AsciiString;
@@ -52,6 +56,9 @@ pub struct Args {
     /// Set the style of log output
     #[arg(long, env = "GRAFBASE_LOG_STYLE", default_value_t = LogStyle::Text)]
     log_style: LogStyle,
+    /// If set, parts of the configuration will get reloaded when changed.
+    #[arg(long, action)]
+    hot_reload: bool,
 }
 
 impl super::Args for Args {
@@ -76,6 +83,14 @@ impl super::Args for Args {
                 })
             }
         }
+    }
+
+    fn config_path(&self) -> Option<&Path> {
+        self.config.as_deref()
+    }
+
+    fn hot_reload(&self) -> bool {
+        self.hot_reload
     }
 
     fn config(&self) -> anyhow::Result<Config> {


### PR DESCRIPTION
<details open>
<summary>:sparkles: <i><h3>Description by Cal</h3></i></summary>

## PR Description
This PR introduces dynamic rate limiting configurations with hot reload functionality, allowing updates to rate limits without server restarts. It includes changes to various files to support this feature, including the addition of a new `hot_reload` module.


<details>
<summary>Diagrams of code changes</summary>

```mermaid
sequenceDiagram
    participant User
    participant GatewayNanny
    participant RateLimiter
    participant ConfigWatcher

    User->>GatewayNanny: Request to update configuration
    GatewayNanny->>ConfigWatcher: Watch for configuration changes
    ConfigWatcher->>RateLimiter: Send updated rate limiting configurations
    RateLimiter->>GatewayNanny: Apply new rate limits
    GatewayNanny->>User: Configuration updated successfully
```

</details>

### Key Issues
None

## Files Changed
<details>
				<summary>File: <b>/Cargo.lock</b></summary>
				Added `notify` dependency for file watching.
			</details><details>
				<summary>File: <b>/cli/crates/federated-dev/src/dev/gateway_nanny.rs</b></summary>
				Updated `new_gateway` function to include a channel for rate limit updates.
			</details><details>
				<summary>File: <b>/engine/crates/integration-tests/src/federation/builder/test_runtime.rs</b></summary>
				Modified `TestRuntime` to include a channel for rate limit updates.
			</details><details>
				<summary>File: <b>/engine/crates/runtime-local/src/rate_limiting/in_memory/key_based.rs</b></summary>
				Refactored `InMemoryRateLimiter` to support dynamic updates via a channel.
			</details><details>
				<summary>File: <b>/engine/crates/runtime-local/src/rate_limiting/redis.rs</b></summary>
				Updated `RedisRateLimiter` to accept dynamic rate limit configurations.
			</details><details>
				<summary>File: <b>/engine/crates/runtime/src/rate_limiting.rs</b></summary>
				Changed `KeyedRateLimitConfig` to use `String` instead of `&str`.
			</details><details>
				<summary>File: <b>/gateway/crates/federated-server/src/config/hot_reload.rs</b></summary>
				Added a new module for watching configuration files and reloading rate limits.
			</details><details>
				<summary>File: <b>/gateway/crates/federated-server/src/config/rate_limit.rs</b></summary>
				Updated `GraphRateLimit` struct to derive `Copy`.
			</details><details>
				<summary>File: <b>/gateway/crates/federated-server/src/server.rs</b></summary>
				Modified `serve` function to handle hot reload configuration.
			</details><details>
				<summary>File: <b>/gateway/crates/gateway-binary/src/args.rs</b></summary>
				Added methods to handle configuration path and hot reload flag.
			</details><details>
				<summary>File: <b>/gateway/crates/gateway-binary/src/main.rs</b></summary>
				Updated main function to pass server configuration including hot reload settings.
			</details>

</details>
- Introduce dynamic rate limiting configurations
- Incorporate hot reload functionality to update rate limits without a server restart
- Allow configuration of hot reload of rate limits in `gateway` server setup

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
